### PR TITLE
Update index.rst

### DIFF
--- a/docs/pygame/life/index.rst
+++ b/docs/pygame/life/index.rst
@@ -238,7 +238,7 @@ i zwróci tylko współrzędne żywych komórek.
 
 .. literalinclude:: code1a.py
     :linenos:
-    :lines: 141-150
+    :lines: 141-152
     :lineno-start: 141
 
 W kodzie powyżej mamy przykład dwóch pętli przy pomocy których sprawdzamy zawartość


### PR DESCRIPTION
Lines 141 - 150 do not show the whole draw_on function. 
2 lines that are missing are: 
```
            thickness = 1
            pygame.draw.rect(surface, color, pygame.locals.Rect(position, size), thickness)
```

Wyświetlane linie kodu nie pokazują całości funkcji malowania. 
Brakuje dwóch linii odpowiedzialnych za rysowanie.