### PR TITLE
draw_on - wyswietlanie całej funkcji

### DIFF
--- a/docs/pygame/life/index.rst
+++ b/docs/pygame/life/index.rst
@@ -221,7 +221,7 @@ Tą metodę wywołamy w metodzie ``GameOfLife.draw``.
 
 .. literalinclude:: code1a.py
     :linenos:
-    :lines: 130-137
+    :lines: 130-139
     :lineno-start: 130
 
 Powyżej wykorzystaliśmy nie istniejącą metodę ``alive_cells`` która jak wynika z


### PR DESCRIPTION
Dla funckji draw_on nie były wyświetlane ostatnie dwie linijki programu wywołujące funkcję rysującą. Linijki: 
        thickness = 1
        pygame.draw.rect(surface, color, pygame.locals.Rect(position, size), thickness)